### PR TITLE
API Updates Oct 2025

### DIFF
--- a/gollu.go
+++ b/gollu.go
@@ -2,6 +2,8 @@ package gollu
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -85,7 +87,7 @@ func (llu *LibreLinkUpClient) Login() (*LLULoginResponse, error) {
 // Connections makes the connections API calls that is used to discover all the device
 // connections available to the user. It can also be used to get the latest value for all
 // the sensors exposed to the user.
-func (llu *LibreLinkUpClient) Connections(ticket LLLULoginResponseAuthTicket) (*LLUConnectionsResponse, error) {
+func (llu *LibreLinkUpClient) Connections(ticket LLLULoginResponseAuthTicket, userId string) (*LLUConnectionsResponse, error) {
 
 	// creating the url
 	url := fmt.Sprintf("%s/%s", LLUUrl, LLUConnectionsEndpoint)
@@ -97,6 +99,10 @@ func (llu *LibreLinkUpClient) Connections(ticket LLLULoginResponseAuthTicket) (*
 	}
 	addCommonHeaders(req)
 	req.Header.Add("authorization", fmt.Sprintf("Bearer %s", ticket.Token))
+
+	hasher := sha256.New()
+	hasher.Write([]byte(userId))
+	req.Header.Add("account-id", hex.EncodeToString(hasher.Sum(nil)))
 
 	// making the call
 	resp, err := http.DefaultClient.Do(req)
@@ -156,5 +162,5 @@ func addCommonHeaders(req *http.Request) {
 	req.Header.Add("content-type", "application/json")
 	req.Header.Add("cache-control", "no-cache")
 	req.Header.Add("product", "llu.android")
-	req.Header.Add("version", "4.7.0")
+	req.Header.Add("version", "4.16.0")
 }

--- a/gollu.go
+++ b/gollu.go
@@ -137,6 +137,10 @@ func (llu *LibreLinkUpClient) Graph(ticket LLLULoginResponseAuthTicket, patientI
 	addCommonHeaders(req)
 	req.Header.Add("authorization", fmt.Sprintf("Bearer %s", ticket.Token))
 
+	hasher := sha256.New()
+	hasher.Write([]byte(patientID))
+	req.Header.Add("account-id", hex.EncodeToString(hasher.Sum(nil)))
+
 	// making the call
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/login.go
+++ b/login.go
@@ -7,9 +7,17 @@ type LLULoginResponse struct {
 }
 
 type LLULoginResponseData struct {
+	User       LLUUserInfo
 	AuthTicket LLLULoginResponseAuthTicket
 }
 
 type LLULoginError struct {
 	Message string
+}
+
+type LLUUserInfo struct {
+	ID        string
+	FirstName string
+	LastName  string
+	Email     string
 }

--- a/managed/client.go
+++ b/managed/client.go
@@ -1,15 +1,17 @@
 package managed
 
 import (
-	"github.com/danishm/gollu"
-	"github.com/pkg/errors"
 	"log/slog"
 	"time"
+
+	"github.com/danishm/gollu"
+	"github.com/pkg/errors"
 )
 
 type LLUClient struct {
-	client gollu.LibreLinkUpClient
-	ticket *gollu.LLLULoginResponseAuthTicket
+	client   gollu.LibreLinkUpClient
+	ticket   *gollu.LLLULoginResponseAuthTicket
+	userInfo *gollu.LLUUserInfo
 }
 
 func NewLLUClient(email, password string) LLUClient {
@@ -75,7 +77,7 @@ func (llc *LLUClient) getConnections() (*gollu.LLUConnectionsResponse, error) {
 		return nil, err
 	}
 	// getting latest value
-	connections, err := llc.client.Connections(*ticket)
+	connections, err := llc.client.Connections(*ticket, llc.userInfo.ID)
 	if err != nil {
 		slog.Error("getConnections()", "error", err.Error())
 		return nil, err
@@ -94,6 +96,7 @@ func (llc *LLUClient) login() error {
 	}
 
 	llc.ticket = &lr.Data.AuthTicket
+	llc.userInfo = &lr.Data.User
 	return nil
 }
 


### PR DESCRIPTION
### Changes
Following updates were needed to work with the LibreLinkup API

- Set `version` to `4.16.0`
- Add `account-id` header to requests